### PR TITLE
Add Selective LoRA Loader support for FLUX 2 Klein 9B

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,7 @@ from .musubi_qwen_image_edit_lora_trainer import MusubiQwenImageEditLoraTrainer
 from .musubi_wan_lora_trainer import MusubiWanLoraTrainer
 from .lora_analyzer import LoRALoaderWithAnalysis
 from .lora_analyzer_v2 import NODE_CLASS_MAPPINGS as V2_NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS as V2_NODE_DISPLAY_NAME_MAPPINGS
-from .selective_lora_loader import SDXLSelectiveLoRALoader, ZImageSelectiveLoRALoader, FLUXSelectiveLoRALoader, WanSelectiveLoRALoader, QwenSelectiveLoRALoader
+from .selective_lora_loader import SDXLSelectiveLoRALoader, ZImageSelectiveLoRALoader, FLUXSelectiveLoRALoader, FLUXKleinSelectiveLoRALoader, WanSelectiveLoRALoader, QwenSelectiveLoRALoader
 from .scheduled_lora_loader import ScheduledLoRALoader
 from .clipboard_image_loader import ClippyRebornImageLoader
 from .image_of_day import ImageOfDayLoader
@@ -40,6 +40,7 @@ NODE_CLASS_MAPPINGS = {
     "SDXLSelectiveLoRALoader": SDXLSelectiveLoRALoader,
     "ZImageSelectiveLoRALoader": ZImageSelectiveLoRALoader,
     "FLUXSelectiveLoRALoader": FLUXSelectiveLoRALoader,
+    "FLUXKleinSelectiveLoRALoader": FLUXKleinSelectiveLoRALoader,
     "WanSelectiveLoRALoader": WanSelectiveLoRALoader,
     "QwenSelectiveLoRALoader": QwenSelectiveLoRALoader,
     "ScheduledLoRALoader": ScheduledLoRALoader,
@@ -60,6 +61,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "SDXLSelectiveLoRALoader": "Selective LoRA Loader (SDXL)",
     "ZImageSelectiveLoRALoader": "Selective LoRA Loader (Z-Image)",
     "FLUXSelectiveLoRALoader": "Selective LoRA Loader (FLUX)",
+    "FLUXKleinSelectiveLoRALoader": "Selective LoRA Loader (FLUX 2 Klein)",
     "WanSelectiveLoRALoader": "Selective LoRA Loader (Wan)",
     "QwenSelectiveLoRALoader": "Selective LoRA Loader (Qwen)",
     "ScheduledLoRALoader": "LoRA Loader (Scheduled)",

--- a/lora_analyzer_v2.py
+++ b/lora_analyzer_v2.py
@@ -708,8 +708,9 @@ def _extract_block_id_v2(key: str, architecture: str) -> str:
         match = re.search(r'blocks[._](\d+)', key)
         return f"block_{match.group(1)}" if match else 'other'
 
-    elif architecture == 'FLUX':
+    elif architecture in ('FLUX', 'FLUX_KLEIN'):
         # FLUX has double blocks (19) and single blocks (38)
+        # FLUX_KLEIN has double blocks (8) and single blocks (24) - same key patterns
         # Different trainers use different naming:
         #   - Standard: double_blocks.N, single_blocks.N
         #   - AI-Toolkit: transformer.transformer_blocks.N (double), transformer.single_transformer_blocks.N (single)
@@ -1137,6 +1138,38 @@ Supports strength scheduling format: 0:.2,.5:.8,1:1.0""",
                                                  if b not in ["double_7", "double_12", "double_16", "single_7", "single_12", "single_16", "single_20"]], "strength": 1.0},
             "Evens Only": {"enabled": [f"double_{i}" for i in range(0, 19, 2)] + [f"single_{i}" for i in range(0, 38, 2)], "strength": 1.0},
             "Odds Only": {"enabled": [f"double_{i}" for i in range(1, 19, 2)] + [f"single_{i}" for i in range(1, 38, 2)], "strength": 1.0},
+            "Custom": None,
+        },
+    },
+    "FLUX_KLEIN": {
+        "node_id": "FLUXKleinAnalyzerSelectiveLoaderV2",
+        "display_name": "FLUX 2 Klein Analyzer + Selective Loader V2",
+        "description": """Combined analyzer and selective loader for FLUX 2 Klein 9B LoRAs.
+Works with both flux-2-klein-9b (distilled) and flux-2-klein-base-9b - same block architecture.
+Analyzes block impact and allows per-block control with strength shaping.
+
+Block Guide (32 total):
+- double_0-7: Double transformer blocks (8 blocks, higher impact)
+- single_0-23: Single transformer blocks (24 blocks, lower impact)
+
+Supports strength scheduling format: 0:.2,.5:.8,1:1.0""",
+        "architecture": "FLUX_KLEIN",
+        "blocks": [f"double_{i}" for i in range(8)] + [f"single_{i}" for i in range(24)] + ["other_weights"],
+        "block_labels": ({f"double_{i}": f"Double {i}" for i in range(8)} |
+                        {f"single_{i}": f"Single {i}" for i in range(24)} |
+                        {"other_weights": "Other Weights"}),
+        "presets": {
+            "Default": {"enabled": "ALL", "strength": 1.0},
+            "All Off": {"enabled": [], "strength": 0.0},
+            "Half Strength": {"enabled": "ALL", "strength": 0.5},
+            "Double Blocks Only": {"enabled": [f"double_{i}" for i in range(8)] + ["other_weights"], "strength": 1.0},
+            "Single Blocks Only": {"enabled": [f"single_{i}" for i in range(24)] + ["other_weights"], "strength": 1.0},
+            "High Impact Double": {"enabled": [f"double_{i}" for i in range(4, 8)], "strength": 1.0},
+            "Face Focus": {"enabled": ["double_4", "double_7", "single_7", "single_12", "single_16", "single_20"], "strength": 1.0},
+            "Style Only (No Face)": {"enabled": [b for b in [f"double_{i}" for i in range(8)] + [f"single_{i}" for i in range(24)]
+                                                 if b not in ["double_4", "double_7", "single_7", "single_12", "single_16", "single_20"]], "strength": 1.0},
+            "Evens Only": {"enabled": [f"double_{i}" for i in range(0, 8, 2)] + [f"single_{i}" for i in range(0, 24, 2)], "strength": 1.0},
+            "Odds Only": {"enabled": [f"double_{i}" for i in range(1, 8, 2)] + [f"single_{i}" for i in range(1, 24, 2)], "strength": 1.0},
             "Custom": None,
         },
     },

--- a/selective_lora_loader.py
+++ b/selective_lora_loader.py
@@ -185,6 +185,28 @@ ZIMAGE_PRESETS = {
     "Custom": None,  # Use individual toggles
 }
 
+# FLUX 2 Klein block presets - 8 double blocks (0-7) + 24 single blocks (0-23) = 32 total
+# Covers both flux-2-klein-9b (distilled) and flux-2-klein-base-9b - same architecture
+FLUX_KLEIN_ALL_BLOCKS = (
+    {f"double_{i}" for i in range(8)} |
+    {f"single_{i}" for i in range(24)}
+)
+FLUX_KLEIN_FACE_BLOCKS = {"double_4", "double_7", "single_7", "single_12", "single_16", "single_20"}
+FLUX_KLEIN_STYLE_BLOCKS = FLUX_KLEIN_ALL_BLOCKS - FLUX_KLEIN_FACE_BLOCKS
+
+FLUX_KLEIN_PRESETS = {
+    "All Blocks": FLUX_KLEIN_ALL_BLOCKS.copy(),
+    "All Off": set(),
+    "Double Blocks Only": {f"double_{i}" for i in range(8)},
+    "Single Blocks Only": {f"single_{i}" for i in range(24)},
+    "High Impact Double": {f"double_{i}" for i in range(4, 8)},
+    "Face Focus": FLUX_KLEIN_FACE_BLOCKS.copy(),
+    "Style Only (No Face)": FLUX_KLEIN_STYLE_BLOCKS.copy(),
+    "Evens Only": {f"double_{i}" for i in range(0, 8, 2)} | {f"single_{i}" for i in range(0, 24, 2)},
+    "Odds Only": {f"double_{i}" for i in range(1, 8, 2)} | {f"single_{i}" for i in range(1, 24, 2)},
+    "Custom": None,
+}
+
 # FLUX block presets - 19 double blocks (0-18) + 38 single blocks (0-37) = 57 total
 FLUX_ALL_BLOCKS = (
     {f"double_{i}" for i in range(19)} |
@@ -1074,10 +1096,167 @@ TIP: Use 'LoRA Loader + Analyzer' first to see which blocks matter for your LoRA
         return {"ui": {"analysis_json": [analysis_json or ""]}, "result": (model_lora, clip_lora, info)}
 
 
+class FLUXKleinSelectiveLoRALoader:
+    """
+    Selective LoRA Loader for FLUX 2 Klein 9B models.
+
+    Covers both flux-2-klein-9b (distilled) and flux-2-klein-base-9b - same block architecture.
+    Toggle individual blocks on/off to control which parts of the LoRA are applied.
+    Use the LoRA Analyzer first to see which blocks have the most impact.
+
+    Block Guide (32 total):
+    - double_0-7: Double transformer blocks (8 blocks, higher impact)
+    - single_0-23: Single transformer blocks (24 blocks, lower impact)
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        inputs = {
+            "required": {
+                "model": ("MODEL",),
+                "clip": ("CLIP",),
+                "lora_name": (folder_paths.get_filename_list("loras"), {
+                    "tooltip": "FLUX 2 Klein LoRA file to load"
+                }),
+                "strength": ("FLOAT", {
+                    "default": 1.0,
+                    "min": -2.0,
+                    "max": 2.0,
+                    "step": 0.05,
+                    "tooltip": "Overall LoRA strength"
+                }),
+                "preset": (list(FLUX_KLEIN_PRESETS.keys()), {
+                    "default": "All Blocks",
+                    "tooltip": "Quick preset selection. Choose 'Custom' to use individual toggles below."
+                }),
+            },
+        }
+
+        # Add double block toggles and strengths (0-7)
+        for i in range(8):
+            inputs["required"][f"double_{i}"] = ("BOOLEAN", {"default": True})
+            inputs["required"][f"double_{i}_str"] = ("FLOAT", {
+                "default": 1.0, "min": -2.0, "max": 2.0, "step": 0.05
+            })
+
+        # Add single block toggles and strengths (0-23)
+        for i in range(24):
+            inputs["required"][f"single_{i}"] = ("BOOLEAN", {"default": True})
+            inputs["required"][f"single_{i}_str"] = ("FLOAT", {
+                "default": 1.0, "min": -2.0, "max": 2.0, "step": 0.05
+            })
+
+        # Other weights (keys not matching known blocks)
+        inputs["required"]["other_weights"] = ("BOOLEAN", {"default": True})
+        inputs["required"]["other_weights_str"] = ("FLOAT", {
+            "default": 1.0, "min": -2.0, "max": 2.0, "step": 0.05
+        })
+
+        inputs["optional"] = {
+            "lora_path_opt": ("STRING", {"forceInput": True, "tooltip": "Optional: Connect from LoRA Analyzer to use its selected LoRA"}),
+            "analysis_json": ("STRING", {"forceInput": True, "tooltip": "Optional: Connect from LoRA Analyzer for impact-colored checkboxes"}),
+        }
+
+        return inputs
+
+    RETURN_TYPES = ("MODEL", "CLIP", "STRING")
+    RETURN_NAMES = ("model", "clip", "info")
+    OUTPUT_NODE = True
+    FUNCTION = "load_lora"
+    CATEGORY = "loaders/lora"
+    DESCRIPTION = """Selective LoRA loader for FLUX 2 Klein 9B. Toggle blocks on/off.
+Works with both flux-2-klein-9b (distilled) and flux-2-klein-base-9b.
+
+TIP: Use 'LoRA Loader + Analyzer' first to see which blocks matter for your LoRA.
+Double blocks (0-7) typically have more impact than single blocks (0-23)."""
+
+    def load_lora(self, model, clip, lora_name, strength, preset, **kwargs):
+        lora_path_opt = kwargs.get("lora_path_opt")
+        analysis_json = kwargs.get("analysis_json")
+
+        self._analysis_json = analysis_json
+
+        if preset != "Custom":
+            enabled_blocks = FLUX_KLEIN_PRESETS[preset].copy()
+            block_strengths = {b: 1.0 for b in enabled_blocks}
+            other_enabled = preset != "All Off"
+            other_str = 1.0
+            using_preset = preset
+        else:
+            enabled_blocks = set()
+            block_strengths = {}
+            for i in range(8):
+                block_id = f"double_{i}"
+                if kwargs.get(block_id, True):
+                    enabled_blocks.add(block_id)
+                    block_strengths[block_id] = kwargs.get(f"{block_id}_str", 1.0)
+            for i in range(24):
+                block_id = f"single_{i}"
+                if kwargs.get(block_id, True):
+                    enabled_blocks.add(block_id)
+                    block_strengths[block_id] = kwargs.get(f"{block_id}_str", 1.0)
+            other_enabled = kwargs.get("other_weights", True)
+            other_str = kwargs.get("other_weights_str", 1.0)
+            using_preset = None
+
+        if lora_path_opt and os.path.exists(lora_path_opt):
+            lora_path = lora_path_opt
+        else:
+            lora_path = folder_paths.get_full_path("loras", lora_name)
+        if not lora_path or not os.path.exists(lora_path):
+            return (model, clip, "Error: LoRA not found")
+
+        if lora_path.endswith('.safetensors'):
+            lora_state_dict = load_file(lora_path)
+        else:
+            lora_state_dict = torch.load(lora_path, map_location='cpu')
+
+        filtered_dict = {}
+        for key, value in lora_state_dict.items():
+            block_id = _extract_block_id_flux(key)
+            if block_id in enabled_blocks:
+                blk_str = block_strengths.get(block_id, 1.0)
+                filtered_dict[key] = value * blk_str if blk_str != 1.0 else value
+            elif block_id == 'other' and other_enabled:
+                filtered_dict[key] = value * other_str if other_str != 1.0 else value
+
+        original_count = len(lora_state_dict)
+        filtered_count = len(filtered_dict)
+
+        if filtered_count == 0:
+            return {"ui": {"analysis_json": [analysis_json or ""]}, "result": (model, clip, "Warning: All blocks disabled, no LoRA applied")}
+
+        model_lora, clip_lora = comfy.sd.load_lora_for_models(
+            model, clip, filtered_dict, strength, strength
+        )
+
+        all_blocks = [f"double_{i}" for i in range(8)] + [f"single_{i}" for i in range(24)]
+        disabled = [b for b in all_blocks if b not in enabled_blocks]
+        scaled = [f"{b}={block_strengths[b]:.2f}" for b in enabled_blocks if block_strengths.get(b, 1.0) != 1.0]
+
+        info = f"Loaded {filtered_count}/{original_count} tensors\n"
+        info += f"Preset: {using_preset}\n" if using_preset else "Preset: Custom\n"
+        info += f"Enabled: {len(enabled_blocks)}/32 blocks\n"
+        if scaled:
+            info += f"Scaled: {', '.join(scaled)}\n"
+        if disabled:
+            disabled_double = [b for b in disabled if b.startswith("double_")]
+            disabled_single = [b for b in disabled if b.startswith("single_")]
+            if disabled_double:
+                info += f"Disabled double: {', '.join(b.replace('double_', '') for b in disabled_double)}\n"
+            if disabled_single:
+                info += f"Disabled single: {', '.join(b.replace('single_', '') for b in disabled_single)}"
+        else:
+            info += "All blocks enabled"
+
+        return {"ui": {"analysis_json": [analysis_json or ""]}, "result": (model_lora, clip_lora, info)}
+
+
 NODE_CLASS_MAPPINGS = {
     "SDXLSelectiveLoRALoader": SDXLSelectiveLoRALoader,
     "ZImageSelectiveLoRALoader": ZImageSelectiveLoRALoader,
     "FLUXSelectiveLoRALoader": FLUXSelectiveLoRALoader,
+    "FLUXKleinSelectiveLoRALoader": FLUXKleinSelectiveLoRALoader,
     "WanSelectiveLoRALoader": WanSelectiveLoRALoader,
     "QwenSelectiveLoRALoader": QwenSelectiveLoRALoader,
 }
@@ -1086,6 +1265,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "SDXLSelectiveLoRALoader": "Selective LoRA Loader (SDXL)",
     "ZImageSelectiveLoRALoader": "Selective LoRA Loader (Z-Image)",
     "FLUXSelectiveLoRALoader": "Selective LoRA Loader (FLUX)",
+    "FLUXKleinSelectiveLoRALoader": "Selective LoRA Loader (FLUX 2 Klein)",
     "WanSelectiveLoRALoader": "Selective LoRA Loader (Wan)",
     "QwenSelectiveLoRALoader": "Selective LoRA Loader (Qwen)",
 }

--- a/web/js/dynamic_inputs.js
+++ b/web/js/dynamic_inputs.js
@@ -277,6 +277,30 @@ const SELECTIVE_LOADER_PRESETS = {
             "Odds Only": { enabled: [...Array.from({length: 9}, (_, i) => `double_${i * 2 + 1}`), ...Array.from({length: 19}, (_, i) => `single_${i * 2 + 1}`)], strength: 1.0 },
         }
     },
+    "FLUXKleinSelectiveLoRALoader": {
+        blocks: [
+            ...Array.from({length: 8}, (_, i) => `double_${i}`),
+            ...Array.from({length: 24}, (_, i) => `single_${i}`),
+            "other_weights"
+        ],
+        presets: {
+            "All Blocks": { enabled: "ALL", strength: 1.0 },
+            "All Off": { enabled: [], strength: 0.0 },
+            "Double Blocks Only": { enabled: [...Array.from({length: 8}, (_, i) => `double_${i}`), "other_weights"], strength: 1.0 },
+            "Single Blocks Only": { enabled: [...Array.from({length: 24}, (_, i) => `single_${i}`), "other_weights"], strength: 1.0 },
+            "High Impact Double": { enabled: Array.from({length: 4}, (_, i) => `double_${i + 4}`), strength: 1.0 },
+            "Face Focus": { enabled: ["double_4", "double_7", "single_7", "single_12", "single_16", "single_20"], strength: 1.0 },
+            "Style Only (No Face)": {
+                enabled: [
+                    ...Array.from({length: 8}, (_, i) => `double_${i}`),
+                    ...Array.from({length: 24}, (_, i) => `single_${i}`)
+                ].filter(b => !["double_4", "double_7", "single_7", "single_12", "single_16", "single_20"].includes(b)),
+                strength: 1.0
+            },
+            "Evens Only": { enabled: [...Array.from({length: 4}, (_, i) => `double_${i * 2}`), ...Array.from({length: 12}, (_, i) => `single_${i * 2}`)], strength: 1.0 },
+            "Odds Only": { enabled: [...Array.from({length: 4}, (_, i) => `double_${i * 2 + 1}`), ...Array.from({length: 12}, (_, i) => `single_${i * 2 + 1}`)], strength: 1.0 },
+        }
+    },
     "WanSelectiveLoRALoader": {
         blocks: [...Array.from({length: 40}, (_, i) => `block_${i}`), "other_weights"],
         presets: {
@@ -367,6 +391,31 @@ const SELECTIVE_LOADER_PRESETS = {
             },
             "Evens Only": { enabled: [...Array.from({length: 10}, (_, i) => `double_${i * 2}`), ...Array.from({length: 19}, (_, i) => `single_${i * 2}`)], strength: 1.0 },
             "Odds Only": { enabled: [...Array.from({length: 9}, (_, i) => `double_${i * 2 + 1}`), ...Array.from({length: 19}, (_, i) => `single_${i * 2 + 1}`)], strength: 1.0 },
+        }
+    },
+    "FLUXKleinAnalyzerSelectiveLoaderV2": {
+        blocks: [
+            ...Array.from({length: 8}, (_, i) => `double_${i}`),
+            ...Array.from({length: 24}, (_, i) => `single_${i}`),
+            "other_weights"
+        ],
+        presets: {
+            "Default": { enabled: "ALL", strength: 1.0 },
+            "All Off": { enabled: [], strength: 0.0 },
+            "Half Strength": { enabled: "ALL", strength: 0.5 },
+            "Double Blocks Only": { enabled: [...Array.from({length: 8}, (_, i) => `double_${i}`), "other_weights"], strength: 1.0 },
+            "Single Blocks Only": { enabled: [...Array.from({length: 24}, (_, i) => `single_${i}`), "other_weights"], strength: 1.0 },
+            "High Impact Double": { enabled: Array.from({length: 4}, (_, i) => `double_${i + 4}`), strength: 1.0 },
+            "Face Focus": { enabled: ["double_4", "double_7", "single_7", "single_12", "single_16", "single_20"], strength: 1.0 },
+            "Style Only (No Face)": {
+                enabled: [
+                    ...Array.from({length: 8}, (_, i) => `double_${i}`),
+                    ...Array.from({length: 24}, (_, i) => `single_${i}`)
+                ].filter(b => !["double_4", "double_7", "single_7", "single_12", "single_16", "single_20"].includes(b)),
+                strength: 1.0
+            },
+            "Evens Only": { enabled: [...Array.from({length: 4}, (_, i) => `double_${i * 2}`), ...Array.from({length: 12}, (_, i) => `single_${i * 2}`)], strength: 1.0 },
+            "Odds Only": { enabled: [...Array.from({length: 4}, (_, i) => `double_${i * 2 + 1}`), ...Array.from({length: 12}, (_, i) => `single_${i * 2 + 1}`)], strength: 1.0 },
         }
     },
     "WanAnalyzerSelectiveLoaderV2": {
@@ -476,12 +525,14 @@ app.registerExtension({
             "SDXLSelectiveLoRALoader",
             "ZImageSelectiveLoRALoader",
             "FLUXSelectiveLoRALoader",
+            "FLUXKleinSelectiveLoRALoader",
             "WanSelectiveLoRALoader",
             "QwenSelectiveLoRALoader",
             // V2 Combined Analyzer + Selective Loaders
             "ZImageAnalyzerSelectiveLoaderV2",
             "SDXLAnalyzerSelectiveLoaderV2",
             "FLUXAnalyzerSelectiveLoaderV2",
+            "FLUXKleinAnalyzerSelectiveLoaderV2",
             "WanAnalyzerSelectiveLoaderV2",
             "QwenAnalyzerSelectiveLoaderV2",
             // Model Layer Editor nodes (base model per-block control)


### PR DESCRIPTION
## What

Adds selective LoRA block loading support for FLUX 2 Klein 9B models.

FLUX 2 Klein 9B has a smaller architecture than standard FLUX:
- **8 double blocks** (vs 19 in standard FLUX)
- **24 single blocks** (vs 38 in standard FLUX)
- **32 total blocks**

Covers both `flux-2-klein-9b` (distilled) and `flux-2-klein-base-9b` — same block architecture, same key naming conventions as standard FLUX (`double_blocks.N`, `single_blocks.N`).

## Changes

- `selective_lora_loader.py`: Add `FLUXKleinSelectiveLoRALoader` (V1 node)
- `lora_analyzer_v2.py`: Add `FLUX_KLEIN` config for V2 combined analyzer+loader node
- `web/js/dynamic_inputs.js`: Register Klein nodes with correct block configs and presets
- `__init__.py`: Register `FLUXKleinSelectiveLoRALoader`

## New nodes

- **Selective LoRA Loader (FLUX 2 Klein)** — V1 standalone loader
- **FLUX 2 Klein Analyzer + Selective Loader V2** — V2 combined analyzer+loader

## Note

This PR is intentionally kept minimal (Klein support only). In my fork I am merging this together with PR #30 (bidirectional sync + slider improvements). If you are interested in that feature as well, it is available there.