### PR TITLE
fix: match SimpleTuner Z-Image LoRA key prefix in block extraction

### DIFF
--- a/lora_analyzer_v2.py
+++ b/lora_analyzer_v2.py
@@ -710,7 +710,8 @@ def _extract_block_id_v2(key: str, architecture: str) -> str:
 
     elif architecture == 'ZIMAGE':
         # AI-Toolkit format: diffusion_model.layers.N.attention/adaLN_modulation
-        match = re.search(r'diffusion_model\.layers\.(\d+)', key)
+        # SimpleTuner comfyui format: diffusion_model.transformer.layers.N (Lumina2 preserves transformer prefix)
+        match = re.search(r'diffusion_model\.(?:transformer\.)?layers\.(\d+)', key)
         if match:
             return f"layer_{match.group(1)}"
         # Musubi Tuner format: lora_unet_layers_N_attention_...


### PR DESCRIPTION
## Summary

- `_extract_block_id_v2()` regex now matches `diffusion_model.transformer.layers.N` in addition to `diffusion_model.layers.N`
- Enables per-layer gating for SimpleTuner-trained Z-Image/Lumina2 LoRAs exported with `lora_key_format: comfyui`

## Problem

SimpleTuner's comfyui export format preserves the `transformer.` prefix for Lumina2/Z-Image models (they're in `comfy_preserve_prefix_families`), producing keys like:

```
diffusion_model.transformer.layers.0.attention.to_q.lora_A.weight
```

The existing regex `diffusion_model\.layers\.(\d+)` misses these, so all 240 layer keys fall into the `other` bucket. The per-layer toggle UI still renders 30 layer controls, but toggling them has no effect -- all layer weights are controlled only by the "Other Weights" toggle.

The `context_refiner` and `noise_refiner` keys are unaffected (they use substring matching).

## Fix

```python
# Before
match = re.search(r'diffusion_model\.layers\.(\d+)', key)

# After
match = re.search(r'diffusion_model\.(?:transformer\.)?layers\.(\d+)', key)
```

Makes `transformer.` optional in the match. No behavior change for AI-Toolkit, Musubi, or LyCORIS format LoRAs.

## Test plan

- [x] Verified regex matches both `diffusion_model.layers.N` and `diffusion_model.transformer.layers.N`
- [x] Verified regex does NOT match bare `transformer.layers.N` (default SimpleTuner format without comfyui export)
- [x] Verified refiner key detection (`context_refiner`, `noise_refiner`) is unaffected
- [x] Verified `lora_unet_layers_N` and `lycoris_layers_N` patterns are unaffected