### PR TITLE
Fix selective loader slider range mismatch

### DIFF
--- a/web/js/dynamic_inputs.js
+++ b/web/js/dynamic_inputs.js
@@ -883,9 +883,9 @@ app.registerExtension({
                 labelWidth: 95,
                 valueWidth: 38,
                 gap: 6,
-                min: -2.0,
-                max: 2.0,
-                step: 0.05,  // Hardcoded - ComfyUI widget options not reliably accessible
+                min: strength.options?.min ?? -2.0,
+                max: strength.options?.max ?? 2.0,
+                step: strength.options?.step ?? 0.05,
                 getLayout: function(widgetWidth) {
                     const sliderWidth = widgetWidth - this.margin - this.checkboxSize - this.gap - this.labelWidth - this.gap - this.valueWidth - this.margin - this.gap;
                     const checkboxX = this.margin;


### PR DESCRIPTION
Small fix for the selective loader sliders.

The combined slider UI was drawing with the widget's real min/max, but the drag handler was still hardcoded to -2..2.
Selective loaders use -5..5, so the handle could not reach the full track and left dead space at the ends.

This updates the drag metadata to use the actual widget min/max/step.