### PR TITLE
Add Krea 2 LoRA block support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Buy Me A Coffee](https://img.shields.io/badge/Buy%20Me%20A%20Coffee-Support-yellow.svg)](https://buymeacoffee.com/lorasandlenses)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-**Train**, **analyze**, **selectively load by block**, and **edit base models** for **SDXL, SD 1.5, FLUX, Z-Image, Qwen Image, Qwen Image Edit, and Wan 2.2** directly inside ComfyUI. One unified interface across three training backends, plus powerful analysis, block-level loading, strength scheduling, and model editing tools.
+**Train**, **analyze**, **selectively load by block**, and **edit base models** for **SDXL, SD 1.5, FLUX, Z-Image, Qwen Image, Qwen Image Edit, Wan 2.2, and Krea 2 LoRAs** directly inside ComfyUI. One unified interface across three training backends, plus powerful analysis, block-level loading, strength scheduling, and model editing tools.
 
 > **Version 2 Now Available:** Combined analyzer + selective loader nodes with strength scheduling and LoRA saving!
 >
@@ -17,10 +17,10 @@
 | **Musubi Tuner** | Z-Image, Z-Image Base, FLUX Klein 4B/9B, Qwen Image, Qwen Image Edit, Wan 2.2 | Cutting-edge models, smaller LoRAs, excellent VRAM efficiency |
 | **AI-Toolkit** | FLUX.1-dev, Z-Image, Wan 2.2 alternative training pipeline |
 
-**8 architectures. 3 training backends. 31 nodes total. **
+**8 training architectures plus Krea 2 LoRA block loading. 3 training backends. 33 nodes total. **
 
 - 10 trainer nodes
-- 13 selective loaders (5 V1 + 8 V2 combined)
+- 15 selective loaders (6 V1 + 9 V2 combined)
 - 2 analyzers (V1 + V2)
 - 6 model layer editors
 - 1 utility node
@@ -59,6 +59,7 @@ The V2 nodes combine analysis and selective loading into a single node, with pow
 - **Save Refined LoRA** - Export your block-filtered LoRA as a new file
 - **40+ Schedule Presets** - Fades, bell curves, pulses, step functions, and inverted versions
 - **Extra Z-Image Blocks** - Control context_refiner, noise_refiner, final_layer, x_embedder
+- **Krea 2 LoRA Block Loading** - Control 28 main SingleStreamBlocks, with non-main Krea 2 Linear layers grouped under `other_weights`
 - **LoKR/LoHa Support** - Proper handling of decomposed LoRA formats (common for Z-Image)
 
 ### Model Layer Editor Nodes
@@ -213,6 +214,7 @@ Search for these in ComfyUI:
 - **Selective LoRA Loader (FLUX)** - Load FLUX LoRAs with per-block toggles (57 blocks: 19 double + 38 single)
 - **Selective LoRA Loader (Wan)** - Load Wan LoRAs with per-block toggles (40 blocks)
 - **Selective LoRA Loader (Qwen)** - Load Qwen LoRAs with per-block toggles (60 blocks)
+- **Selective LoRA Loader (Krea 2)** - Load Krea 2 LoRAs with per-block toggles (28 main blocks)
 
 **V2 Combined Analyzer + Selective Loader (Recommended):**
 
@@ -223,6 +225,7 @@ These combine analysis and selective loading in one node, with strength scheduli
 - **FLUX Analyzer + Selective Loader V2** - 57 blocks with strength scheduling
 - **Wan Analyzer + Selective Loader V2** - 40 blocks with strength scheduling
 - **Qwen Analyzer + Selective Loader V2** - 60 blocks with strength scheduling
+- **Krea 2 Analyzer + Selective Loader V2** - 28 main blocks with strength scheduling
 - **FLUX Klein 4B Analyzer + Selective Loader V2** - 25 blocks (5 double + 20 single) with strength scheduling
 - **FLUX Klein 9B Analyzer + Selective Loader V2** - 32 blocks (8 double + 24 single) with strength scheduling
 - **LoRA Loader + Analyzer V2** - Basic V2 analyzer without selective loading

--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,7 @@ from .musubi_qwen_image_edit_lora_trainer import MusubiQwenImageEditLoraTrainer
 from .musubi_wan_lora_trainer import MusubiWanLoraTrainer
 from .lora_analyzer import LoRALoaderWithAnalysis
 from .lora_analyzer_v2 import NODE_CLASS_MAPPINGS as V2_NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS as V2_NODE_DISPLAY_NAME_MAPPINGS
-from .selective_lora_loader import SDXLSelectiveLoRALoader, ZImageSelectiveLoRALoader, FLUXSelectiveLoRALoader, WanSelectiveLoRALoader, QwenSelectiveLoRALoader
+from .selective_lora_loader import SDXLSelectiveLoRALoader, ZImageSelectiveLoRALoader, FLUXSelectiveLoRALoader, WanSelectiveLoRALoader, QwenSelectiveLoRALoader, Krea2SelectiveLoRALoader
 from .scheduled_lora_loader import ScheduledLoRALoader
 from .model_layer_analyzer import NODE_CLASS_MAPPINGS as MODEL_LAYER_NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS as MODEL_LAYER_NODE_DISPLAY_NAME_MAPPINGS
 
@@ -56,6 +56,7 @@ NODE_CLASS_MAPPINGS = {
     "FLUXSelectiveLoRALoader": FLUXSelectiveLoRALoader,
     "WanSelectiveLoRALoader": WanSelectiveLoRALoader,
     "QwenSelectiveLoRALoader": QwenSelectiveLoRALoader,
+    "Krea2SelectiveLoRALoader": Krea2SelectiveLoRALoader,
     "ScheduledLoRALoader": ScheduledLoRALoader,
 }
 
@@ -76,6 +77,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "FLUXSelectiveLoRALoader": "Selective LoRA Loader (FLUX)",
     "WanSelectiveLoRALoader": "Selective LoRA Loader (Wan)",
     "QwenSelectiveLoRALoader": "Selective LoRA Loader (Qwen)",
+    "Krea2SelectiveLoRALoader": "Selective LoRA Loader (Krea 2)",
     "ScheduledLoRALoader": "LoRA Loader (Scheduled)",
 }
 

--- a/lora_analyzer.py
+++ b/lora_analyzer.py
@@ -27,6 +27,14 @@ def _detect_architecture(keys):
     if any('transformer_blocks' in k and any(x in k for x in ['img_mlp', 'txt_mlp', 'img_mod', 'txt_mod']) for k in keys_lower):
         return 'QWEN_IMAGE'
 
+    # Check for Krea 2 (28 main SingleStreamBlocks plus txtfusion/projection modules)
+    if 'lora_krea2' in keys_str or 'krea2' in keys_str or 'krea_2' in keys_str:
+        return 'KREA2'
+    if any(x in keys_str for x in ['txtfusion', 'txtmlp', 'tmlp', 'tproj']) and any(re.search(r'blocks[._]\d+', k) for k in keys_lower):
+        return 'KREA2'
+    if any(re.search(r'blocks[._]\d+[._].*(?:attn[._])?(?:wq|wk|wv|wo|gate)', k) for k in keys_lower):
+        return 'KREA2'
+
     # Check for Flux formats - must check BEFORE Z-Image since both have single_transformer_blocks
     # AI-Toolkit format: transformer.single_transformer_blocks / transformer.double_blocks
     if any('transformer.single_transformer_blocks' in k or 'transformer.double_blocks' in k for k in keys_lower):
@@ -92,6 +100,12 @@ def _extract_block_id(key: str, architecture: str) -> str:
 
     if architecture == 'QWEN_IMAGE':
         match = re.search(r'transformer_blocks[._](\d+)', key)
+        return f"block_{match.group(1)}" if match else 'other'
+
+    elif architecture == 'KREA2':
+        if any(part in key_lower for part in ['txtfusion', 'txtmlp', 'tmlp', 'tproj', 'first', 'last']):
+            return 'other'
+        match = re.search(r'blocks[._](\d+)', key_lower)
         return f"block_{match.group(1)}" if match else 'other'
 
     elif architecture == 'ZIMAGE':

--- a/lora_analyzer_v2.py
+++ b/lora_analyzer_v2.py
@@ -395,6 +395,9 @@ def _detect_from_metadata(metadata: dict) -> str:
     # Check modelspec.architecture (newer LoRAs)
     arch = metadata.get('modelspec.architecture', '').lower()
 
+    if 'krea' in arch or 'krea2' in arch or 'k2' == arch:
+        return 'KREA2'
+
     # Check for FLUX Klein variants first (before generic FLUX). Match loosely on
     # "klein" + size so the distilled and base variants both resolve, e.g.
     # flux-2-klein-9b AND flux-2-klein-base-9b.
@@ -411,6 +414,8 @@ def _detect_from_metadata(metadata: dict) -> str:
 
     # Check ss_base_model_version (Kohya format)
     base_model = metadata.get('ss_base_model_version', '').lower()
+    if 'krea' in base_model or 'krea2' in base_model:
+        return 'KREA2'
     # Check Klein variants first (loose match catches *-klein-base-9b etc.)
     if 'klein' in base_model and '4b' in base_model:
         return 'FLUX_KLEIN_4B'
@@ -425,6 +430,8 @@ def _detect_from_metadata(metadata: dict) -> str:
 
     # Check ss_network_module (Kohya format)
     network_module = metadata.get('ss_network_module', '').lower()
+    if 'lora_krea2' in network_module or 'krea' in network_module:
+        return 'KREA2'
     if 'flux' in network_module:
         return 'FLUX'
     if 'zimage' in network_module or 'z_image' in network_module:
@@ -436,6 +443,8 @@ def _detect_from_metadata(metadata: dict) -> str:
 
     # Check ss_sd_model_name for hints
     model_name = metadata.get('ss_sd_model_name', '').lower()
+    if 'krea' in model_name or 'krea2' in model_name:
+        return 'KREA2'
     if 'flux' in model_name:
         return 'FLUX'
     if 'sdxl' in model_name or 'xl' in model_name:
@@ -454,6 +463,7 @@ def _count_unique_blocks(keys: list) -> dict:
         'flux_single': set(),
         'wan_blocks': set(),
         'qwen_blocks': set(),
+        'krea2_blocks': set(),
         'sdxl_blocks': set(),
         'sd15_blocks': set(),
     }
@@ -507,6 +517,12 @@ def _count_unique_blocks(keys: list) -> dict:
             if match:
                 counts['qwen_blocks'].add(int(match.group(1)))
 
+        # Krea 2 main SingleStreamBlocks (0-27)
+        if any(x in key_lower for x in ['txtfusion', 'txtmlp', 'tmlp', 'tproj', 'wq', 'wk', 'wv', 'wo', 'gate', 'mlp']):
+            match = re.search(r'blocks[._](\d+)', key_lower)
+            if match:
+                counts['krea2_blocks'].add(int(match.group(1)))
+
         # SDXL/SD15 blocks
         match = re.search(r'input_blocks?[._]?(\d+)', key_lower)
         if match:
@@ -525,6 +541,7 @@ def _score_architecture(keys: list, num_keys: int, block_counts: dict) -> dict:
         'FLUX': 0,
         'FLUX_KLEIN_4B': 0,
         'FLUX_KLEIN_9B': 0,
+        'KREA2': 0,
         'ZIMAGE': 0,
         'WAN': 0,
         'SDXL': 0,
@@ -533,6 +550,18 @@ def _score_architecture(keys: list, num_keys: int, block_counts: dict) -> dict:
 
     keys_lower = [k.lower() for k in keys]
     keys_str = ' '.join(keys_lower)
+
+    # === KREA2 scoring ===
+    if 'lora_krea2' in keys_str or 'krea2' in keys_str or 'krea_2' in keys_str:
+        scores['KREA2'] += 80
+    if any(x in keys_str for x in ['txtfusion', 'txtmlp', 'tmlp', 'tproj']) and any(re.search(r'blocks[._]\d+', k) for k in keys_lower):
+        scores['KREA2'] += 60
+    if any(re.search(r'blocks[._]\d+[._].*(?:attn[._])?(?:wq|wk|wv|wo|gate)', k) for k in keys_lower):
+        scores['KREA2'] += 45
+    if block_counts['krea2_blocks'] == 28:
+        scores['KREA2'] += 35
+    elif 20 <= block_counts['krea2_blocks'] <= 28:
+        scores['KREA2'] += 20
 
     # === QWEN_IMAGE scoring ===
     if any('transformer_blocks' in k and any(x in k for x in ['img_mlp', 'txt_mlp', 'img_mod', 'txt_mod']) for k in keys_lower):
@@ -642,6 +671,9 @@ def _score_architecture(keys: list, num_keys: int, block_counts: dict) -> dict:
         scores['SD15'] -= 30
     if scores['FLUX'] > 40:
         scores['SD15'] -= 30
+    if scores['KREA2'] > 40:
+        scores['WAN'] -= 20
+        scores['SD15'] -= 30
 
     return scores
 
@@ -716,6 +748,12 @@ def _extract_block_id_v2(key: str, architecture: str) -> str:
 
     if architecture == 'QWEN_IMAGE':
         match = re.search(r'transformer_blocks[._](\d+)', key)
+        return f"block_{match.group(1)}" if match else 'other'
+
+    elif architecture == 'KREA2':
+        if any(part in key_lower for part in ['txtfusion', 'txtmlp', 'tmlp', 'tproj', 'first', 'last']):
+            return 'other'
+        match = re.search(r'blocks[._](\d+)', key_lower)
         return f"block_{match.group(1)}" if match else 'other'
 
     elif architecture == 'ZIMAGE':
@@ -1347,6 +1385,38 @@ Supports strength scheduling format: 0:.2,.5:.8,1:1.0""",
             "Late Singles (12-23)": {"enabled": [f"single_{i}" for i in range(12, 24)], "strength": 1.0},
             "Evens Only": {"enabled": [f"double_{i}" for i in range(0, 8, 2)] + [f"single_{i}" for i in range(0, 24, 2)], "strength": 1.0},
             "Odds Only": {"enabled": [f"double_{i}" for i in range(1, 8, 2)] + [f"single_{i}" for i in range(1, 24, 2)], "strength": 1.0},
+            "Custom": None,
+        },
+    },
+    "KREA2": {
+        "node_id": "Krea2AnalyzerSelectiveLoaderV2",
+        "display_name": "Krea 2 Analyzer + Selective Loader V2",
+        "description": """Combined analyzer and selective loader for Krea 2 LoRAs.
+Analyzes block impact and allows per-block control with strength shaping.
+
+Block Guide (28 main SingleStreamBlocks):
+- block_0-8: Early main blocks
+- block_9-18: Mid main blocks
+- block_19-27: Late main blocks
+
+Non-main-block Krea 2 Linear layers such as first, last.linear, tmlp, txtmlp, tproj,
+and txtfusion are controlled by other_weights.
+
+Supports strength scheduling format: 0:.2,.5:.8,1:1.0""",
+        "architecture": "KREA2",
+        "blocks": [f"block_{i}" for i in range(28)] + ["other_weights"],
+        "block_labels": {f"block_{i}": f"Block {i}" for i in range(28)} | {"other_weights": "Other Weights"},
+        "presets": {
+            "Default": {"enabled": "ALL", "strength": 1.0},
+            "All Off": {"enabled": [], "strength": 0.0},
+            "Half Strength": {"enabled": "ALL", "strength": 0.5},
+            "Late Only (21-27)": {"enabled": [f"block_{i}" for i in range(21, 28)] + ["other_weights"], "strength": 1.0},
+            "Mid-Late (14-27)": {"enabled": [f"block_{i}" for i in range(14, 28)] + ["other_weights"], "strength": 1.0},
+            "Skip Early (7-27)": {"enabled": [f"block_{i}" for i in range(7, 28)] + ["other_weights"], "strength": 1.0},
+            "Mid Only (9-18)": {"enabled": [f"block_{i}" for i in range(9, 19)], "strength": 1.0},
+            "Early Only (0-8)": {"enabled": [f"block_{i}" for i in range(9)], "strength": 1.0},
+            "Evens Only": {"enabled": [f"block_{i}" for i in range(0, 28, 2)], "strength": 1.0},
+            "Odds Only": {"enabled": [f"block_{i}" for i in range(1, 28, 2)], "strength": 1.0},
             "Custom": None,
         },
     },

--- a/selective_lora_loader.py
+++ b/selective_lora_loader.py
@@ -21,6 +21,12 @@ def _detect_architecture(keys):
 
     if any('transformer_blocks' in k and any(x in k for x in ['img_mlp', 'txt_mlp', 'img_mod', 'txt_mod']) for k in keys_lower):
         return 'QWEN_IMAGE'
+    if 'lora_krea2' in keys_str or 'krea2' in keys_str or 'krea_2' in keys_str:
+        return 'KREA2'
+    if any(x in keys_str for x in ['txtfusion', 'txtmlp', 'tmlp', 'tproj']) and any(re.search(r'blocks[._]\d+', k) for k in keys_lower):
+        return 'KREA2'
+    if any(re.search(r'blocks[._]\d+[._].*(?:attn[._])?(?:wq|wk|wv|wo|gate)', k) for k in keys_lower):
+        return 'KREA2'
     if any('diffusion_model.layers.' in k and ('attention' in k or 'adaln' in k.lower()) for k in keys_lower):
         return 'ZIMAGE'
     # Musubi Tuner Z-Image format (lora_unet_layers_N_attention_...)
@@ -149,6 +155,17 @@ def _extract_block_id_qwen(key: str) -> Optional[int]:
     return None
 
 
+def _extract_block_id_krea2(key: str) -> Optional[int]:
+    """Extract main SingleStreamBlock number for Krea 2 architecture."""
+    key_lower = key.lower()
+    if any(part in key_lower for part in ['txtfusion', 'txtmlp', 'tmlp', 'tproj', 'first', 'last']):
+        return None
+    match = re.search(r'blocks[._](\d+)', key_lower)
+    if match:
+        return int(match.group(1))
+    return None
+
+
 # SDXL block presets - only blocks with attention layers that LoRA trains
 # SDXL has: text_encoder_1, text_encoder_2, input_4/5/7/8, unet_mid, output_0-5
 # Other input/output blocks are ResNet-only (no attention) and not trained by standard LoRA
@@ -245,6 +262,20 @@ QWEN_PRESETS = {
     "Early Only (0-29)": set(range(30)),
     "Evens Only": set(range(0, 60, 2)),
     "Odds Only": set(range(1, 60, 2)),
+    "Custom": None,  # Use individual toggles
+}
+
+# Krea 2 block presets - 28 main SingleStreamBlocks
+KREA2_PRESETS = {
+    "All Blocks": set(range(28)),
+    "All Off": set(),  # All blocks disabled including other_weights
+    "Late Only (21-27)": set(range(21, 28)),
+    "Mid-Late (14-27)": set(range(14, 28)),
+    "Skip Early (7-27)": set(range(7, 28)),
+    "Mid Only (9-18)": set(range(9, 19)),
+    "Early Only (0-8)": set(range(9)),
+    "Evens Only": set(range(0, 28, 2)),
+    "Odds Only": set(range(1, 28, 2)),
     "Custom": None,  # Use individual toggles
 }
 
@@ -1074,12 +1105,170 @@ TIP: Use 'LoRA Loader + Analyzer' first to see which blocks matter for your LoRA
         return {"ui": {"analysis_json": [analysis_json or ""]}, "result": (model_lora, clip_lora, info)}
 
 
+class Krea2SelectiveLoRALoader:
+    """
+    Selective LoRA Loader for Krea 2 models.
+
+    Toggle individual main SingleStreamBlocks on/off to control which parts of the LoRA are applied.
+    Non-main-block Linear layers such as first, last.linear, tmlp, txtmlp, tproj, and txtfusion are
+    controlled by other_weights.
+
+    Block Guide (28 total):
+    - block_0-8: Early main blocks
+    - block_9-18: Mid main blocks
+    - block_19-27: Late main blocks
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        inputs = {
+            "required": {
+                "model": ("MODEL",),
+                "clip": ("CLIP",),
+                "lora_name": (folder_paths.get_filename_list("loras"), {
+                    "tooltip": "Krea 2 LoRA file to load"
+                }),
+                "strength": ("FLOAT", {
+                    "default": 1.0,
+                    "min": -5.0,
+                    "max": 5.0,
+                    "step": 0.05,
+                    "tooltip": "Overall LoRA strength"
+                }),
+                "preset": (list(KREA2_PRESETS.keys()), {
+                    "default": "All Blocks",
+                    "tooltip": "Quick preset selection. Choose 'Custom' to use individual toggles below."
+                }),
+            },
+        }
+
+        # Add main block toggles and strengths (0-27)
+        for i in range(28):
+            inputs["required"][f"block_{i}"] = ("BOOLEAN", {"default": True})
+            inputs["required"][f"block_{i}_str"] = ("FLOAT", {
+                "default": 1.0, "min": -5.0, "max": 5.0, "step": 0.05
+            })
+
+        # Other Krea 2 Linear layers: first, last.linear, tmlp, txtmlp, tproj, txtfusion, etc.
+        inputs["required"]["other_weights"] = ("BOOLEAN", {"default": True})
+        inputs["required"]["other_weights_str"] = ("FLOAT", {
+            "default": 1.0, "min": -5.0, "max": 5.0, "step": 0.05
+        })
+
+        inputs["optional"] = {
+            "lora_path_opt": ("STRING", {"forceInput": True, "tooltip": "Optional: Connect from LoRA Analyzer to use its selected LoRA"}),
+            "analysis_json": ("STRING", {"forceInput": True, "tooltip": "Optional: Connect from LoRA Analyzer for impact-colored checkboxes"}),
+        }
+
+        return inputs
+
+    RETURN_TYPES = ("MODEL", "CLIP", "STRING")
+    RETURN_NAMES = ("model", "clip", "info")
+    OUTPUT_NODE = True
+    FUNCTION = "load_lora"
+    CATEGORY = "loaders/lora"
+    DESCRIPTION = """Selective LoRA loader for Krea 2. Toggle the 28 main SingleStreamBlocks on/off.
+
+TIP: Use 'LoRA Loader + Analyzer' first to see which blocks matter for your LoRA.
+Use other_weights for non-main-block Krea 2 modules like txtfusion, tmlp, txtmlp, tproj, first, and last.linear."""
+
+    def load_lora(self, model, clip, lora_name, strength, preset, **kwargs):
+        # Get optional inputs from kwargs
+        lora_path_opt = kwargs.get("lora_path_opt")
+        analysis_json = kwargs.get("analysis_json")
+
+        # Store analysis_json for UI callback
+        self._analysis_json = analysis_json
+        # Use preset or custom toggles
+        if preset != "Custom":
+            enabled_blocks = KREA2_PRESETS[preset].copy()
+            block_strengths = {i: 1.0 for i in enabled_blocks}
+            # All Off preset disables other_weights too
+            other_enabled = preset != "All Off"
+            other_str = 1.0
+            using_preset = preset
+        else:
+            # Build from individual toggles and strengths
+            enabled_blocks = set()
+            block_strengths = {}
+            for i in range(28):
+                if kwargs.get(f"block_{i}", True):
+                    enabled_blocks.add(i)
+                    block_strengths[i] = kwargs.get(f"block_{i}_str", 1.0)
+            other_enabled = kwargs.get("other_weights", True)
+            other_str = kwargs.get("other_weights_str", 1.0)
+            using_preset = None
+
+        # Load LoRA - use optional path if provided, otherwise use dropdown selection
+        if lora_path_opt and os.path.exists(lora_path_opt):
+            lora_path = lora_path_opt
+        else:
+            lora_path = folder_paths.get_full_path("loras", lora_name)
+        if not lora_path or not os.path.exists(lora_path):
+            return (model, clip, "Error: LoRA not found")
+
+        if lora_path.endswith('.safetensors'):
+            lora_state_dict = load_file(lora_path)
+        else:
+            lora_state_dict = torch.load(lora_path, map_location='cpu')
+
+        # Filter and scale tensors by block strength
+        filtered_dict = {}
+        for key, value in lora_state_dict.items():
+            block_num = _extract_block_id_krea2(key)
+            if block_num is not None:
+                if block_num in enabled_blocks:
+                    blk_str = block_strengths.get(block_num, 1.0)
+                    filtered_dict[key] = value * blk_str if blk_str != 1.0 else value
+            elif other_enabled:
+                # Include non-main-block keys based on other_weights setting
+                filtered_dict[key] = value * other_str if other_str != 1.0 else value
+
+        original_count = len(lora_state_dict)
+        filtered_count = len(filtered_dict)
+
+        if filtered_count == 0:
+            return {"ui": {"analysis_json": [analysis_json or ""]}, "result": (model, clip, "Warning: All blocks disabled, no LoRA applied")}
+
+        # Apply filtered LoRA
+        model_lora, clip_lora = comfy.sd.load_lora_for_models(
+            model, clip, filtered_dict, strength, strength
+        )
+
+        disabled_blocks = [i for i in range(28) if i not in enabled_blocks]
+        scaled = [f"{i}={block_strengths[i]:.2f}" for i in enabled_blocks if block_strengths.get(i, 1.0) != 1.0]
+
+        info = f"Loaded {filtered_count}/{original_count} tensors\n"
+        if using_preset:
+            info += f"Preset: {using_preset}\n"
+        else:
+            info += "Preset: Custom\n"
+        info += f"Enabled: {len(enabled_blocks)}/28 blocks\n"
+        info += f"Other weights: {'enabled' if other_enabled else 'disabled'}"
+        if other_enabled and other_str != 1.0:
+            info += f" ({other_str:.2f})"
+        info += "\n"
+        if scaled:
+            info += f"Scaled: {', '.join(scaled[:10])}"
+            if len(scaled) > 10:
+                info += f" (+{len(scaled)-10} more)\n"
+            else:
+                info += "\n"
+        if disabled_blocks:
+            info += f"Disabled: {', '.join(str(b) for b in disabled_blocks)}"
+        else:
+            info += "All blocks enabled"
+
+        return {"ui": {"analysis_json": [analysis_json or ""]}, "result": (model_lora, clip_lora, info)}
+
+
 NODE_CLASS_MAPPINGS = {
     "SDXLSelectiveLoRALoader": SDXLSelectiveLoRALoader,
     "ZImageSelectiveLoRALoader": ZImageSelectiveLoRALoader,
     "FLUXSelectiveLoRALoader": FLUXSelectiveLoRALoader,
     "WanSelectiveLoRALoader": WanSelectiveLoRALoader,
     "QwenSelectiveLoRALoader": QwenSelectiveLoRALoader,
+    "Krea2SelectiveLoRALoader": Krea2SelectiveLoRALoader,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -1088,4 +1277,5 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "FLUXSelectiveLoRALoader": "Selective LoRA Loader (FLUX)",
     "WanSelectiveLoRALoader": "Selective LoRA Loader (Wan)",
     "QwenSelectiveLoRALoader": "Selective LoRA Loader (Qwen)",
+    "Krea2SelectiveLoRALoader": "Selective LoRA Loader (Krea 2)",
 }

--- a/web/js/dynamic_inputs.js
+++ b/web/js/dynamic_inputs.js
@@ -307,6 +307,21 @@ const SELECTIVE_LOADER_PRESETS = {
             "Odds Only": { enabled: Array.from({length: 30}, (_, i) => `block_${i * 2 + 1}`), strength: 1.0 },
         }
     },
+    "Krea2SelectiveLoRALoader": {
+        blocks: [...Array.from({length: 28}, (_, i) => `block_${i}`), "other_weights"],
+        presets: {
+            "Default": { enabled: "ALL", strength: 1.0 },
+            "All Off": { enabled: [], strength: 0.0 },
+            "Half Strength": { enabled: "ALL", strength: 0.5 },
+            "Late Only (21-27)": { enabled: [...Array.from({length: 7}, (_, i) => `block_${i + 21}`), "other_weights"], strength: 1.0 },
+            "Mid-Late (14-27)": { enabled: [...Array.from({length: 14}, (_, i) => `block_${i + 14}`), "other_weights"], strength: 1.0 },
+            "Skip Early (7-27)": { enabled: [...Array.from({length: 21}, (_, i) => `block_${i + 7}`), "other_weights"], strength: 1.0 },
+            "Mid Only (9-18)": { enabled: Array.from({length: 10}, (_, i) => `block_${i + 9}`), strength: 1.0 },
+            "Early Only (0-8)": { enabled: Array.from({length: 9}, (_, i) => `block_${i}`), strength: 1.0 },
+            "Evens Only": { enabled: Array.from({length: 14}, (_, i) => `block_${i * 2}`), strength: 1.0 },
+            "Odds Only": { enabled: Array.from({length: 14}, (_, i) => `block_${i * 2 + 1}`), strength: 1.0 },
+        }
+    },
     // V2 Combined Analyzer + Selective Loaders
     "ZImageAnalyzerSelectiveLoaderV2": {
         blocks: [...Array.from({length: 30}, (_, i) => `layer_${i}`), "context_refiner", "noise_refiner", "final_layer", "x_embedder", "other_weights"],
@@ -397,6 +412,21 @@ const SELECTIVE_LOADER_PRESETS = {
             "Early Only (0-29)": { enabled: Array.from({length: 30}, (_, i) => `block_${i}`), strength: 1.0 },
             "Evens Only": { enabled: Array.from({length: 30}, (_, i) => `block_${i * 2}`), strength: 1.0 },
             "Odds Only": { enabled: Array.from({length: 30}, (_, i) => `block_${i * 2 + 1}`), strength: 1.0 },
+        }
+    },
+    "Krea2AnalyzerSelectiveLoaderV2": {
+        blocks: [...Array.from({length: 28}, (_, i) => `block_${i}`), "other_weights"],
+        presets: {
+            "Default": { enabled: "ALL", strength: 1.0 },
+            "All Off": { enabled: [], strength: 0.0 },
+            "Half Strength": { enabled: "ALL", strength: 0.5 },
+            "Late Only (21-27)": { enabled: [...Array.from({length: 7}, (_, i) => `block_${i + 21}`), "other_weights"], strength: 1.0 },
+            "Mid-Late (14-27)": { enabled: [...Array.from({length: 14}, (_, i) => `block_${i + 14}`), "other_weights"], strength: 1.0 },
+            "Skip Early (7-27)": { enabled: [...Array.from({length: 21}, (_, i) => `block_${i + 7}`), "other_weights"], strength: 1.0 },
+            "Mid Only (9-18)": { enabled: Array.from({length: 10}, (_, i) => `block_${i + 9}`), strength: 1.0 },
+            "Early Only (0-8)": { enabled: Array.from({length: 9}, (_, i) => `block_${i}`), strength: 1.0 },
+            "Evens Only": { enabled: Array.from({length: 14}, (_, i) => `block_${i * 2}`), strength: 1.0 },
+            "Odds Only": { enabled: Array.from({length: 14}, (_, i) => `block_${i * 2 + 1}`), strength: 1.0 },
         }
     },
     // FLUX Klein 4B (5 double + 20 single blocks)
@@ -516,12 +546,14 @@ app.registerExtension({
             "FLUXSelectiveLoRALoader",
             "WanSelectiveLoRALoader",
             "QwenSelectiveLoRALoader",
+            "Krea2SelectiveLoRALoader",
             // V2 Combined Analyzer + Selective Loaders
             "ZImageAnalyzerSelectiveLoaderV2",
             "SDXLAnalyzerSelectiveLoaderV2",
             "FLUXAnalyzerSelectiveLoaderV2",
             "WanAnalyzerSelectiveLoaderV2",
             "QwenAnalyzerSelectiveLoaderV2",
+            "Krea2AnalyzerSelectiveLoaderV2",
             "FluxKlein4BAnalyzerSelectiveLoaderV2",
             "FluxKlein9BAnalyzerSelectiveLoaderV2",
             // Model Layer Editor nodes (base model per-block control)


### PR DESCRIPTION
Adds Krea 2 support to the LoRA analysis and selective loading nodes.

What this adds:
- Krea 2 detection in the V1 and V2 LoRA analyzers
- Selective LoRA Loader (Krea 2)
- Krea 2 Analyzer + Selective Loader V2
- 28 main SingleStreamBlock controls: block_0 through block_27
- frontend preset/widget support for the new Krea 2 nodes

Implementation notes:
- Non-main Krea 2 Linear layers such as txtfusion, tmlp, txtmlp, tproj, first, and last are grouped under other_weights.
- This is for Krea 2 LoRA analysis/loading only; it does not add Krea 2 training support.
- The block layout follows the current Musubi Krea 2 implementation, where Krea 2 has 28 main SingleStreamBlocks.

Caveats:
- This may still have bugs. Krea 2 support is new and I only tested it with the LoRAs/workflows I have available.
- The analyzer color/impact detection may need refinement, especially around how much weight should be attributed to other_weights versus the 28 main blocks.
- In my testing, the Krea 2 selective loader itself appears to work well for block manipulation.

Tested:
- Python compile check for the touched Python files
- frontend JS syntax check
- smoke tests for Krea 2 detection and block extraction
- manual Krea 2 LoRA loading/block manipulation in ComfyUI
